### PR TITLE
Add min width to labels

### DIFF
--- a/src/components/ContactForm.vue
+++ b/src/components/ContactForm.vue
@@ -91,6 +91,10 @@ export default {
   align-items: center;
 }
 
+.form__field > label {
+  min-width: 95px;
+}
+
 input,
 textarea {
   border: 1px solid #0000006b;


### PR DESCRIPTION
Fixed input fields not staying the same size by adding a min width to the labels.